### PR TITLE
Fixed error while sending a message to a group

### DIFF
--- a/src/Telebot/Contracts.cs
+++ b/src/Telebot/Contracts.cs
@@ -53,6 +53,15 @@
             if( !File.Exists(filePath) )
                 throw new FileNotFoundException($"Unable to find the requested file at '{filePath}'.", filePath);
         }
+
+        internal static void EnsureNotZero(long value, [NotNull] string paramName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(paramName), "!string.IsNullOrWhiteSpace(paramName)");
+
+            if (value == 0)
+                throw new ArgumentException($"{paramName} cannot be 0.", paramName);
+        }
+
         #endregion
     }
 }

--- a/src/Telebot/Telebot.audio.cs
+++ b/src/Telebot/Telebot.audio.cs
@@ -65,7 +65,7 @@
         /// </returns>
         public Task<Message> SendAudioAsync(long chatId, [NotNull] string audioId, int duration = 0, string performer = null, string title = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendAudioAsync(chatId.ToString(), audioId, duration, performer, title, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -89,7 +89,7 @@
         /// </returns>
         public Task<Message> SendAudioAsync(long chatId, [NotNull] Stream audioStream, string fileName, int duration, string performer = null, string title = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendAudioAsync(chatId.ToString(), audioStream, fileName, duration, performer, title, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.contact.cs
+++ b/src/Telebot/Telebot.contact.cs
@@ -43,7 +43,7 @@
         /// </exception>
         public Task<Message> SendContactAsync(long chatId, [NotNull] string phoneNumber, [NotNull] string firstName, string lastName = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
 
             return this.SendContactAsync(chatId.ToString(), phoneNumber, firstName, lastName, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }

--- a/src/Telebot/Telebot.cs
+++ b/src/Telebot/Telebot.cs
@@ -396,7 +396,7 @@
         /// <exception cref="System.ArgumentException">userId must be a number greater than zero.</exception>
         public Task<bool> KickChatMemberAsync(long chatId, long userId, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.KickChatMemberAsync(chatId.ToString(), userId, cancellationToken);
         }
 
@@ -522,7 +522,7 @@
         /// <exception cref="System.ArgumentException">userId must be a number greater than zero.</exception>
         public Task<bool> UnbanChatMemberAsync(long chatId, long userId, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.KickChatMemberAsync(chatId.ToString(), userId, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.document.cs
+++ b/src/Telebot/Telebot.document.cs
@@ -37,7 +37,7 @@
         /// </remarks>
         public Task<Message> SendDocumentAsync(long chatId, [NotNull] string documentId, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendDocumentAsync(chatId.ToString(), documentId, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -153,7 +153,7 @@
         /// </remarks>
         public Task<Message> SendDocumentFromFileAsync(long chatId, [NotNull] string filePath, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendDocumentFromFileAsync(chatId.ToString(), filePath, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.location.cs
+++ b/src/Telebot/Telebot.location.cs
@@ -29,6 +29,7 @@
         /// </returns>
         public Task<Message> SendLocationAsync(long chatId, double latitude, double longitude, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendLocationAsync(chatId.ToString(), latitude, longitude, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.message-edit.cs
+++ b/src/Telebot/Telebot.message-edit.cs
@@ -34,7 +34,7 @@
         /// </returns>
         public Task<Message> EditMessageCaptionAsync(long chatId, long messageId, [NotNull] string caption, InlineKeyboardMarkup replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.EditMessageCaptionAsync(chatId.ToString(), messageId, caption, replyMarkup, cancellationToken);
         }
 
@@ -112,7 +112,7 @@
         /// </returns>
         public Task<Message> EditMessageReplyMarkupAsync(long chatId, long messageId, InlineKeyboardMarkup replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));            
+            Contracts.EnsureNotZero(chatId, nameof(chatId));            
             return this.EditMessageReplyMarkupAsync(chatId.ToString(), messageId, replyMarkup, cancellationToken);
         }
 
@@ -222,7 +222,7 @@
         /// </returns>
         public Task<Message> EditMessageTextAsync(long chatId, long messageId, [NotNull] string text, ParseMode parseMode = ParseMode.Normal, bool disableWebPagePreview = false, InlineKeyboardMarkup replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.EditMessageTextAsync(chatId.ToString(), messageId, text, parseMode, disableWebPagePreview, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.message.cs
+++ b/src/Telebot/Telebot.message.cs
@@ -55,7 +55,7 @@
         /// </returns>
         public Task<Message> ForwardMessageAsync(long chatId, string fromChatId, long messageId, bool disableNotification = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.ForwardMessageAsync(chatId.ToString(), fromChatId, messageId, disableNotification, cancellationToken);
         }
 
@@ -75,7 +75,7 @@
         /// </returns>
         public Task<Message> ForwardMessageAsync(long chatId, long fromChatId, long messageId, bool disableNotification = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.ForwardMessageAsync(chatId.ToString(), fromChatId.ToString(), messageId, disableNotification, cancellationToken);
         }
 
@@ -105,7 +105,7 @@
         /// </remarks>
         public Task<bool> SendChatActionAsync(long chatId, ChatAction action, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendChatActionAsync(chatId.ToString(), action, cancellationToken);
         }
 
@@ -162,7 +162,7 @@
         /// </returns>
         public Task<Message> SendMessageAsync(long chatId, [NotNull] string text, ParseMode parseMode = ParseMode.Normal, bool disableWebPagePreview = false, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendMessageAsync(chatId.ToString(), text, parseMode, disableWebPagePreview, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.photo.cs
+++ b/src/Telebot/Telebot.photo.cs
@@ -32,7 +32,7 @@
         /// </returns>
         public Task<Message> SendPhotoAsync(long chatId, [NotNull] string documentId, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendPhotoAsync(chatId.ToString(), documentId, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -83,7 +83,7 @@
         /// </returns>
         public Task<Message> SendPhotoAsync(long chatId, [NotNull] Stream photoStream, string fileName, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendPhotoAsync(chatId.ToString(), photoStream, fileName, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -136,7 +136,7 @@
         /// </returns>
         public Task<Message> SendPhotoFromFileAsync(long chatId, [NotNull] string filePath, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendPhotoFromFileAsync(chatId.ToString(), filePath, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.sticker.cs
+++ b/src/Telebot/Telebot.sticker.cs
@@ -31,7 +31,7 @@
         /// </returns>
         public Task<Message> SendStickerAsync(long chatId, [NotNull] string stickerId, long replyToMessageId = 0, bool disableNotification = false, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendStickerAsync(chatId.ToString(), stickerId, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -76,7 +76,7 @@
         /// </returns>
         public Task<Message> SendStickerAsync(long chatId, [NotNull] Stream stickerStream, string fileName, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendStickerAsync(chatId.ToString(), stickerStream, fileName, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -128,7 +128,7 @@
         /// </remarks>
         public Task<Message> SendStickerFromFileAsync(long chatId, [NotNull] string filePath, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendStickerFromFileAsync(chatId.ToString(), filePath, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.venue.cs
+++ b/src/Telebot/Telebot.venue.cs
@@ -40,7 +40,7 @@
         /// </returns>
         public Task<Message> SendVenueAsync(long chatId, float latitude, float longitude, [NotNull] string title, [NotNull] string address, string forsquareId = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
 
             return this.SendVenueAsync(chatId.ToString(), latitude, longitude, title, address, forsquareId, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }

--- a/src/Telebot/Telebot.video.cs
+++ b/src/Telebot/Telebot.video.cs
@@ -37,7 +37,7 @@
         /// </remarks>
         public Task<Message> SendVideoAsync(long chatId, [NotNull] string videoId, int duration = 0, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendVideoAsync(chatId.ToString(), videoId, duration, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -100,7 +100,7 @@
         /// </remarks>
         public Task<Message> SendVideoAsync(long chatId, [NotNull] Stream videoStream, string fileName, int duration = 0, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendVideoAsync(chatId.ToString(), videoStream, fileName, duration, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -163,7 +163,7 @@
         /// </remarks>
         public Task<Message> SendVideoFromFileAsync(long chatId, [NotNull] string filePath, int duration = 0, string caption = null, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendVideoFromFileAsync(chatId.ToString(), filePath, duration, caption, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 

--- a/src/Telebot/Telebot.voice.cs
+++ b/src/Telebot/Telebot.voice.cs
@@ -37,7 +37,7 @@
         /// </remarks>
         public Task<Message> SendVoiceAsync(long chatId, [NotNull] string voice, int duration = 0, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendVoiceAsync(chatId.ToString(), voice, duration, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -98,7 +98,7 @@
         /// </remarks>
         public Task<Message> SendVoiceAsync(long chatId, [NotNull] Stream voiceStream, string fileName, int duration = 0, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendVoiceAsync(chatId.ToString(), voiceStream, fileName, duration, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 
@@ -161,7 +161,7 @@
         /// </remarks>
         public Task<Message> SendVoiceFromFileAsync(long chatId, [NotNull] string filePath, int duration = 0, bool disableNotification = false, long replyToMessageId = 0, IReply replyMarkup = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Contracts.EnsurePositiveNumber(chatId, nameof(chatId));
+            Contracts.EnsureNotZero(chatId, nameof(chatId));
             return this.SendVoiceFromFileAsync(chatId.ToString(), filePath, duration, disableNotification, replyToMessageId, replyMarkup, cancellationToken);
         }
 


### PR DESCRIPTION
Telegram groups have negative chatId values. Telebot parameter
validation for chatId parameter has thrown an error when chatId
parameter was a negative number.
